### PR TITLE
Исправление сборки GCC 16 и открытия отсортированных таблиц

### DIFF
--- a/src/gtool1cd/mainwindow.cpp
+++ b/src/gtool1cd/mainwindow.cpp
@@ -210,7 +210,9 @@ void MainWindow::on_openDatabaseFileAction_triggered()
 
 void MainWindow::on_tableListView_doubleClicked(const QModelIndex &index)
 {
-	Table *t = db->get_table(index.row());
+	auto *proxy = qobject_cast<QSortFilterProxyModel*>(ui->tableListView->model());
+	QModelIndex src = proxy ? proxy->mapToSource(index) : index;
+	Table *t = db->get_table(src.row());
 	if (table_windows.find(t) == table_windows.end()) {
 		table_windows[t] = new TableDataWindow(this, t);
 	}

--- a/src/tool1cd/cfapi/APIcfBase.h
+++ b/src/tool1cd/cfapi/APIcfBase.h
@@ -22,6 +22,7 @@
 #ifndef APIcfBaseH
 #define APIcfBaseH
 
+#include <cstdint>
 #include <limits>
 #include <string>
 


### PR DESCRIPTION
## Что исправлено

- добавлен явный `#include <cstdint>` в `APIcfBase.h`, необходимый для сборки GCC 16;
- индекс строки `QSortFilterProxyModel` преобразуется в индекс исходной модели перед открытием таблицы;
- после сортировки списка GUI теперь открывает выбранную таблицу, а не таблицу с тем же номером строки в исходной модели.

## Проверка

- Windows x64, MSYS2 UCRT64;
- GCC 16.1.0, CMake 4.4.0, Qt 6.11.1;
- успешно собраны `ctool1cd` и `gtool1cd`;
- все тесты прошли: 113 проверок в 29 тестах;
- исправление GUI проверено на файловой базе формата 8.3.8.